### PR TITLE
feat: 스토어 수정 API 구현

### DIFF
--- a/src/store/dto/store-response.dto.ts
+++ b/src/store/dto/store-response.dto.ts
@@ -1,0 +1,12 @@
+export class StoreResponseDto {
+  id: string;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+  userId: string;
+  address: string;
+  detailAddress: string;
+  phoneNumber: string;
+  content: string;
+  image: string | null;
+}

--- a/src/store/dto/update-store.dto.ts
+++ b/src/store/dto/update-store.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, IsOptional } from 'class-validator';
+
+export class UpdateStoreDto {
+  @IsString() @IsOptional() name: string;
+  @IsString() @IsOptional() address: string;
+  @IsString() @IsOptional() detailAddress: string;
+  @IsString() @IsOptional() phoneNumber: string;
+  @IsString() @IsOptional() content: string;
+  @IsString() @IsOptional() image?: string | null;
+}

--- a/src/store/store.controller.ts
+++ b/src/store/store.controller.ts
@@ -1,11 +1,12 @@
 import {
-  Body,
   Controller,
-  Post,
-  Req,
   UseGuards,
   Get,
+  Post,
+  Req,
+  Body,
   Param,
+  Patch,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt.guard';
 import type { AuthUser } from '../auth/auth.types';
@@ -13,7 +14,9 @@ import { StoreService } from './store.service';
 import { CreateStoreDto } from './dto/create-store.dto';
 import { StoreDetailDto } from './dto/store-detail.dto';
 import { MyStoreDetailDto } from './dto/mystore-detail.dto';
+import { UpdateStoreDto } from './dto/update-store.dto';
 import { ParseCuidPipe } from 'src/common/pipes/parse-cuid.pipe';
+import { StoreResponseDto } from './dto/store-response.dto';
 
 @Controller('api/stores')
 export class StoreController {
@@ -23,7 +26,6 @@ export class StoreController {
   @Post()
   create(@Req() req: { user: AuthUser }, @Body() dto: CreateStoreDto) {
     const user = req.user;
-
     return this.storeService.createStore(user.userId, user.type, dto);
   }
 
@@ -39,5 +41,17 @@ export class StoreController {
     @Param('storeId', ParseCuidPipe) storeId: string,
   ): Promise<StoreDetailDto> {
     return this.storeService.getStoreDetail(storeId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch(':storeId')
+  updateStore(
+    @Param('storeId', ParseCuidPipe) storeId: string,
+    // @Req() req: { user: AuthUser },
+    @Req() req: Request & { user: { userId: string; type: any } },
+    @Body() dto: UpdateStoreDto,
+  ): Promise<StoreResponseDto> {
+    const user = req.user;
+    return this.storeService.updateStore(storeId, user.userId, user.type, dto);
   }
 }

--- a/src/store/store.repository.ts
+++ b/src/store/store.repository.ts
@@ -13,8 +13,19 @@ export class StoreRepository {
     });
   }
 
+  async findByStoreId(id: string): Promise<Store | null> {
+    return await this.prisma.store.findUnique({ where: { id } });
+  }
+
   async createStore(data: Prisma.StoreCreateInput): Promise<Store> {
     return await this.prisma.store.create({ data });
+  }
+
+  async updateStore(id: string, data: Prisma.StoreUpdateInput): Promise<Store> {
+    return await this.prisma.store.update({
+      where: { id },
+      data,
+    });
   }
 
   async getBySellerId(sellerId: string): Promise<boolean> {
@@ -22,10 +33,6 @@ export class StoreRepository {
       where: { sellerId },
     });
     return storeCount > 0;
-  }
-
-  async findById(id: string): Promise<Store | null> {
-    return await this.prisma.store.findUnique({ where: { id } });
   }
 
   async favoriteCounts(storeId: string): Promise<number> {

--- a/src/store/store.service.ts
+++ b/src/store/store.service.ts
@@ -1,23 +1,25 @@
 import {
+  Injectable,
+  NotFoundException,
   ConflictException,
   ForbiddenException,
-  NotFoundException,
-  Injectable,
+  UnauthorizedException,
 } from '@nestjs/common';
+import { UserType, Prisma } from '@prisma/client';
 import { StoreRepository } from './store.repository';
 import { CreateStoreDto } from './dto/create-store.dto';
 import { StoreDetailDto } from './dto/store-detail.dto';
 import { MyStoreDetailDto } from './dto/mystore-detail.dto';
-import { UserType, Prisma } from '@prisma/client';
+import { UpdateStoreDto } from './dto/update-store.dto';
+import { StoreResponseDto } from './dto/store-response.dto';
 
 @Injectable()
 export class StoreService {
   constructor(private readonly storeRepo: StoreRepository) {}
 
   async createStore(sellerId: string, userType: UserType, dto: CreateStoreDto) {
-    if (userType !== UserType.SELLER) {
+    if (userType !== UserType.SELLER)
       throw new ForbiddenException('SELLER만 스토어를 생성할 수 있습니다.');
-    }
 
     const existStore = await this.storeRepo.getBySellerId(sellerId);
     if (existStore)
@@ -35,9 +37,52 @@ export class StoreService {
 
     return this.storeRepo.createStore(data);
   }
+  async updateStore(
+    storeId: string,
+    userId: string,
+    userType: UserType,
+    dto: UpdateStoreDto,
+  ): Promise<StoreResponseDto> {
+    if (userType !== UserType.SELLER)
+      throw new ForbiddenException('판매자만 스토어를 수정할 수 있습니다. ');
+
+    const store = await this.storeRepo.findByStoreId(storeId);
+    if (!store) throw new NotFoundException('스토어를 찾을 수 없습니다.');
+
+    // 해당 스토어의 판매자가 아닙니다!!!!!! 이걸로 sellerId 넘겨줄 수 있잖아!!!
+    if (store.sellerId !== userId)
+      throw new UnauthorizedException('해당 스토어의 판매자가 아닙니다.');
+
+    // patch니까 들어온 값만 부분 업데이트 하면 되잖아
+    const data: Prisma.StoreUpdateInput = {
+      ...(dto.name !== undefined && { name: dto.name }),
+      ...(dto.address !== undefined && { address: dto.address }),
+      ...(dto.detailAddress !== undefined && {
+        detailAddress: dto.detailAddress,
+      }),
+      ...(dto.phoneNumber !== undefined && { phoneNumber: dto.phoneNumber }),
+      ...(dto.content !== undefined && { content: dto.content }),
+      ...(dto.image !== undefined && { image: dto.image }),
+    };
+
+    const updatedStore = await this.storeRepo.updateStore(storeId, data);
+
+    return {
+      id: updatedStore.id,
+      name: updatedStore.name,
+      createdAt: updatedStore.createdAt, // 이건 스토어 생성 날짜인데 변경 가능??
+      updatedAt: updatedStore.updatedAt,
+      userId: updatedStore.sellerId,
+      address: updatedStore.address,
+      detailAddress: updatedStore.detailAddress,
+      phoneNumber: updatedStore.phoneNumber,
+      content: updatedStore.content,
+      image: updatedStore.image ?? null,
+    };
+  }
 
   async getStoreDetail(storeId: string): Promise<StoreDetailDto> {
-    const store = await this.storeRepo.findById(storeId);
+    const store = await this.storeRepo.findByStoreId(storeId);
     if (!store) throw new NotFoundException('스토어를 찾을 수 없습니다.');
 
     const favoriteCount = await this.storeRepo.favoriteCounts(storeId);


### PR DESCRIPTION
## 📝 요약
- 판매자만 스토어를 수정할 수 있도록 권한 검증을 작성했고, 스웨거에 작성된 명세대로 PATCH 요청이 가능합니다.

## 📝 변경사항
- 판매자 권한 검증 : 판매자만 수정 가능, 해당 스토어의 판매자만 수정 가능, 구매자 수정 불가, 
- 부분 업데이트 로직 작성을 위해서 모든 필드에 `@IsOptional` 활용
- 응답 시 sellerId가 userId에 매핑됨 (스웨거에 맞춤)

## 📝 추가설명
- createdAt, updatedAt은 Prisma에서 자동 관리하지만 스웨거에 작성된 순서에 맞게 추가했습니다.
- 스웨거에 맞게 응답DTO를 따로 정의했습니다.

## 🔗관련 이슈
- Closes #63 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ✅ 테스트 결과
**스토어 수정**
<img width="705" height="503" alt="스크린샷 2025-09-24 오후 2 48 12" src="https://github.com/user-attachments/assets/8a526ba8-39d1-44a6-8356-223d0042e3cb" />
</br>
**판매자만 수정 (구매자가 수정하려고 접근했을 때)**
<img width="702" height="402" alt="스크린샷 2025-09-24 오후 2 48 26" src="https://github.com/user-attachments/assets/2609a42a-8324-4453-920b-ac917dbaef72" />
</br>
**스토어 판매자만 수정 (판매자 자신의 스토어가 아닌 경우)**
<img width="704" height="416" alt="스크린샷 2025-09-24 오후 2 48 47" src="https://github.com/user-attachments/assets/eac145bf-a760-4537-bd9b-701aa8ca6cb8" />