### PR TITLE
refactor: 상품 문의 등록 시 알림 생성 로직 추가

### DIFF
--- a/src/inquiry/inquiry.controller.ts
+++ b/src/inquiry/inquiry.controller.ts
@@ -23,7 +23,7 @@ import { ParseCuidPipe } from 'src/common/pipes/parse-cuid.pipe';
 
 @Controller('api/inquiries')
 export class InquiryController {
-  constructor(private inquiryService: InquiryService) { }
+  constructor(private inquiryService: InquiryService) {}
 
   // 내 문의 목록 조회 (BUYER - 본인이 작성 / SELLER - 본인 상품에 달린 문의)
   @UseGuards(JwtAuthGuard)

--- a/src/inquiry/inquiry.repository.ts
+++ b/src/inquiry/inquiry.repository.ts
@@ -4,7 +4,7 @@ import { PrismaService } from 'src/prisma/prisma.service';
 
 @Injectable()
 export class InquiryRepository {
-  constructor(private prisma: PrismaService) { }
+  constructor(private prisma: PrismaService) {}
 
   // 내 문의 목록 조회 (BUYER - 본인이 작성 / SELLER - 본인 상품에 달린 문의)
   async getMyInquiries(
@@ -18,9 +18,9 @@ export class InquiryRepository {
       userType === UserType.BUYER
         ? { userId, ...(status && { status }) }
         : {
-          product: { store: { sellerId: userId } },
-          ...(status && { status }),
-        };
+            product: { store: { sellerId: userId } },
+            ...(status && { status }),
+          };
 
     // 트랜잭션으로 묶어서 리스트와 count 처리
     const result = await this.prisma.$transaction(async (tx) => {

--- a/src/inquiry/inquiry.service.ts
+++ b/src/inquiry/inquiry.service.ts
@@ -14,7 +14,7 @@ import {
 
 @Injectable()
 export class InquiryService {
-  constructor(private inquiryRepository: InquiryRepository) { }
+  constructor(private inquiryRepository: InquiryRepository) {}
 
   // 내 문의 목록 조회 (BUYER - 본인이 작성 / SELLER - 본인 상품에 달린 문의)
   async getMyInquiries(


### PR DESCRIPTION
## 변경 내용

상품 문의 등록 시 알림이 전달되지 않던 문제를 해결했습니다.

- 상품 문의 등록 트랜잭션에 알림 생성 로직 추가
- 문의 등록 시
  - 판매자에게 `NEW_INQUIRY` 알림 생성
  - 구매자에게 `SYSTEM` 알림 생성
- Product -> Store -> Seller 관계를 통해 판매자 식별
- 문의 생성과 알림 생성을 하나의 트랜잭션으로 처리하여 데이터 정합성 보장

---

## 구현 배경

기존에는 문의(Inquiry)는 정상적으로 생성되었으나, 문의 등록 이벤트와 Notification 도메인이 연결되지 않아 판매자에게 `NEW_INQUIRY` 알림이 전달되지 않는 문제가 있었습니다.

문의 등록이 발생하는 **product 도메인**에서 알림 생성까지 함께 처리하는 것이 흐름 상 가장 자연스럽다고 판단하여 트랜잭션 단위로 로직을 추가했습니다.

---

## 구현 방식

- `prisma.$transaction` 내부에서
  - 상품 및 스토어 조회
  - 문의 생성
  - 판매자/구매자 알림 생성 처리
- Prisma `select` 중첩 조회를 사용하여 필요한 필드만 조회
- 알림 타입은 기존 `NotificationType` enum을 그대로 활용

---

## 확인 사항

- 문의 등록 시 판매자 계정에서 `NEW_INQUIRY` 알림 수신 확인
- 구매자 계정에서 문의 등록 완료 알림 수신 확인
- 기존 알림 조회(SSE) 로직과 정상 연동 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 코드 포맷팅 개선

* **버그 수정**
  * 존재하지 않는 상품에 대한 문의 요청 시 오류 처리 강화

* **기능 개선**
  * 문의 생성 시 판매자 및 구매자 알림 기능 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->