### PR TITLE
refactor: 재고 차감, 품절 검증 및 사이즈 정합성 개선

### DIFF
--- a/prisma/migrations/20260124011320_add_size_id_to_order_item_model/migration.sql
+++ b/prisma/migrations/20260124011320_add_size_id_to_order_item_model/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `sizeId` to the `OrderItem` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "OrderItem" ADD COLUMN     "sizeId" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_sizeId_fkey" FOREIGN KEY ("sizeId") REFERENCES "StockSize"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -221,8 +221,9 @@ model StockSize {
   id   String @id @default(cuid())
   name String
 
-  stocks    Stock[]
-  cartItems CartItem[]
+  stocks     Stock[]
+  cartItems  CartItem[]
+  orderItems OrderItem[]
 }
 
 /**
@@ -277,9 +278,15 @@ model OrderItem {
   productId String
   quantity  Int
   price     Int // 주문 당시 가격 (할인 반영 가능)
+  sizeId    String
 
-  order   Order   @relation(fields: [orderId], references: [id], onDelete: Cascade)
-  product Product @relation(fields: [productId], references: [id], onDelete: Restrict)
+  order   Order     @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  product Product   @relation(fields: [productId], references: [id], onDelete: Restrict)
+  size    StockSize @relation(fields: [sizeId], references: [id], onDelete: Cascade)
+
+  @@index([orderId])
+  @@index([productId])
+  @@index([sizeId])
 }
 
 enum OrderStatus {
@@ -287,6 +294,7 @@ enum OrderStatus {
   CANCELED
   PROCESSING
   SHIPPED
+  
 }
 
 /**

--- a/prisma/seedForDashboard.ts
+++ b/prisma/seedForDashboard.ts
@@ -372,8 +372,8 @@ async function main() {
         totalQuantity: items.reduce((sum, item) => sum + item.quantity, 0),
         items: {
           create: items.map((item) => ({
-            id: `test_orderitem_${date.toISOString()}_${item.productId}`,
             productId: item.productId,
+            sizeId: sizes[0].id, // M 사이즈로 통일
             quantity: item.quantity,
             price: item.price,
           })),

--- a/src/inquiry/inquiry.controller.ts
+++ b/src/inquiry/inquiry.controller.ts
@@ -23,7 +23,7 @@ import { ParseCuidPipe } from 'src/common/pipes/parse-cuid.pipe';
 
 @Controller('api/inquiries')
 export class InquiryController {
-  constructor(private inquiryService: InquiryService) { }
+  constructor(private inquiryService: InquiryService) {}
 
   // 내 문의 목록 조회 (BUYER - 본인이 작성 / SELLER - 본인 상품에 달린 문의)
   @UseGuards(JwtAuthGuard)

--- a/src/inquiry/inquiry.repository.ts
+++ b/src/inquiry/inquiry.repository.ts
@@ -4,7 +4,7 @@ import { PrismaService } from 'src/prisma/prisma.service';
 
 @Injectable()
 export class InquiryRepository {
-  constructor(private prisma: PrismaService) { }
+  constructor(private prisma: PrismaService) {}
 
   // 내 문의 목록 조회 (BUYER - 본인이 작성 / SELLER - 본인 상품에 달린 문의)
   async getMyInquiries(
@@ -18,9 +18,9 @@ export class InquiryRepository {
       userType === UserType.BUYER
         ? { userId, ...(status && { status }) }
         : {
-          product: { store: { sellerId: userId } },
-          ...(status && { status }),
-        };
+            product: { store: { sellerId: userId } },
+            ...(status && { status }),
+          };
 
     // 트랜잭션으로 묶어서 리스트와 count 처리
     const result = await this.prisma.$transaction(async (tx) => {

--- a/src/inquiry/inquiry.service.ts
+++ b/src/inquiry/inquiry.service.ts
@@ -14,7 +14,7 @@ import {
 
 @Injectable()
 export class InquiryService {
-  constructor(private inquiryRepository: InquiryRepository) { }
+  constructor(private inquiryRepository: InquiryRepository) {}
 
   // 내 문의 목록 조회 (BUYER - 본인이 작성 / SELLER - 본인 상품에 달린 문의)
   async getMyInquiries(

--- a/src/orders/dto/create-order-item.dto.ts
+++ b/src/orders/dto/create-order-item.dto.ts
@@ -13,7 +13,7 @@ export class CreateOrderItemDto {
   @ApiProperty({ example: 3, description: '사이즈 ID' })
   @IsInt()
   @Transform(({ value }) => Number(value))
-  sizeId: number;
+  sizeId: string;
 
   @ApiProperty({ example: 1, description: '수량' })
   @IsInt()

--- a/src/orders/orders.repository.ts
+++ b/src/orders/orders.repository.ts
@@ -36,13 +36,9 @@ export class OrdersRepository {
             product: {
               include: {
                 store: true,
-                stocks: {
-                  include: {
-                    size: true,
-                  },
-                },
               },
             },
+            size: true, // OrderItem.size -> item.size로 주문한 사이즈 응답에서 사용 가능
           },
         },
         payments: true,


### PR DESCRIPTION
## 주문 생성 로직 개선

### 문제 상황
- 주문 생성 시 재고(Stock)가 차감되지 않아 품절 상태가 발생하지 않음
- 재고는 size 단위로 관리되지만 OrderItem에는 size 정보가 없어 데이터 정합성이 깨짐
- 품절 상품도 장바구니/주문이 가능했고, 관련 알림 발생 지점이 불명확했음
- 주문 응답에서 구매한 사이즈가 아닌 product.stocks[0]이 내려갈 수 있는 구조였음

---

### 주요 변경 사항
- 주문 생성 트랜잭션에 **Stock 조건부 차감 로직** 추가
- `OrderItem`에 `sizeId` 저장하여 재고 단위(size)와 주문 데이터 일치
- 재고 부족 시 주문 차단 및 알림 생성
  - 구매자: `OUT_OF_STOCK_CART`
  - 판매자: `OUT_OF_STOCK_ORDER`
- 재고 차감 후 수량이 0이 된 상품에 대해 판매자 `OUT_OF_STOCK_SELLER` 알림 생성
- 주문 상세/목록 응답에서 **OrderItem.size relation을 사용해 구매한 사이즈 정확히 반환**

---

### 기대 효과
- 주문 시 재고가 실제로 감소하며 초과 판매 방지
- 품절 상품에 대한 주문 및 결제 사전 차단
- 구매자/판매자에게 상황에 맞는 알림 제공
- 주문 응답 데이터의 사이즈 정합성 확보

---

### 참고
- 장바구니 기반 주문 구조를 유지하면서 재고/알림 로직을 주문 도메인에 집중시킴
- 동시 주문 상황에서도 안전하도록 `updateMany + quantity 조건` 방식 사용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문 항목에 사이즈 정보 추적 기능 추가
  * 문의 및 재고 상태에 대한 알림 시스템 강화
  * 재고 부족 시 구매자 및 판매자에게 실시간 알림 제공

* **개선사항**
  * 주문 처리 시 재고 관리 로직 최적화
  * 데이터베이스 인덱싱으로 조회 성능 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->